### PR TITLE
fix button displayif problem

### DIFF
--- a/replace2.js
+++ b/replace2.js
@@ -366,10 +366,13 @@ transform.render = async (obj, divId, previousResults = {}) => {
         end = i + 1;
         if (cnt == 0) break;
       }
+      // need to have the displayif=... in the variable display_if otherwise if
+      // you have displayif={displayif} displayif will be false if empty.
       let display_if = !!match[4] ? match.input.substring(match.input.indexOf(match[4]), end - 1).trim() : "";
+      display_if = (!!display_if) ? `displayif=${display_if}` : ""
       let label_end = match.input.substring(end).search(/\n|(?:<br>)/) + end;
       let label = match.input.substring(end, label_end);
-      let replacement = `<div class='response' style='margin-top:15px' displayif='${display_if}'><input type='radio' name='${radioElementName}' value='${value}' id='${radioElementName}_${value}'></input><label id='${labelID}' style='font-weight: normal; padding-left:5px;' for='${radioElementName}_${value}'>${label}</label></div>`;
+      let replacement = `<div class='response' style='margin-top:15px' '${display_if}'><input type='radio' name='${radioElementName}' value='${value}' id='${radioElementName}_${value}'></input><label id='${labelID}' style='font-weight: normal; padding-left:5px;' for='${radioElementName}_${value}'>${label}</label></div>`;
       return match.input.substring(0, match.index) + replacement + match.input.substring(label_end);
     }
     /*


### PR DESCRIPTION
string.replace(/regex/) does not work with recursive patterns.  I had to create a function that given the start of a radio button find the appropriate end of the button, the appropriate displayif string, and the appropriate label (up to end-of-line).

It appears to work,  please check my code and let me know if you find anyhing that fails.

Thank you!!!
