### PR TITLE
location.reload() logic move

### DIFF
--- a/questionnaire.js
+++ b/questionnaire.js
@@ -993,9 +993,7 @@ export async function submitQuestionnaire(store, questName) {
     formData[`${questName}.COMPLETED`] = true;
     formData[`${questName}.COMPLETED_TS`] = new Date();
     try {
-      store(formData).then(() => {
-        location.reload();
-      });
+      store(formData)
     } catch (e) {
       console.log("Store failed", e);
     }


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/759
-----
Background Details
* Quest shouldn't be trying to reload the form when we submit, it should be handled by whatever is calling Quest if that functionality is needed
-----
Technical Changes
* removed `.then()` function block after call to `store()` when a questionnaire is submitted
