### PR TITLE
Removing updateTree() Code

### DIFF
--- a/quest.js
+++ b/quest.js
@@ -14,7 +14,7 @@ async function startUp() {
         "rendering",
         previousResults
       ); // <-- this is where quest.js is engaged
-      // transform.render({url: 'https://jonasalmeida.github.io/privatequest/demo2.txt&run'}, 'rendering') // <-- this is where quest.js is engaged
+      
       if (document.querySelector(".question") != null) {
         document.querySelector(".question").classList.add("active");
       }
@@ -39,16 +39,6 @@ async function startUp() {
     ta.onkeyup()
   }
 
-  /*var q = (location.search + location.hash).replace(/[\#\?]/g, "");
-    if (q.length > 3) {
-      if (!q.startsWith("config")) {
-        ta.value = await (await fetch(q.split("&")[0])).text(); // getting the first of markup&css
-      } else {
-        moduleParams.config = config;
-        ta.value = await (await fetch(config.markdown)).text();
-      }
-      ta.onkeyup();
-    } */
   ta.style.width =
     parseInt(ta.parentElement.style.width.slice(0, -1)) - 5 + "%";
 

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -853,25 +853,6 @@ function showModal(norp, retrieve, store, rootElement) {
 
 let tempObj = {};
 
-async function updateTree() {
-  if (moduleParams?.renderObj?.updateTree) {
-    moduleParams.renderObj.updateTree(moduleParams.questName, questionQueue)
-  }
-  updateTreeInLocalForage()
-}
-
-async function updateTreeInLocalForage() {
-  // We dont have questName yet, don't bother saving the tree yet...
-  if (!('questName' in moduleParams)) {
-    return
-  }
-
-  let questName = moduleParams.questName;
-  // do you want a JSON string or a JS Object in LF???
-  // await localforage.setItem(questName + ".treeJSON", questionQueue.JSON());
-  await localforage.setItem(questName + ".treeJSON", questionQueue.toVanillaObject());
-}
-
 function getNextQuestionId(currentFormElement) {
   // get the next question from the questionQueue
   // if it exists... otherwise get the next look at the
@@ -925,9 +906,6 @@ async function nextPage(norp, retrieve, store, rootElement) {
   let questName = moduleParams.questName;
   tempObj[questionElement.id] = questionElement.value;
 
-  //Check if questionElement exists first so its not pushing undefineds
-  //TODO if store is not defined, call lfstore -> redefine store to be store or lfstore
-  //if (questionElement.value) {
 
   let formData = {}
   formData.module = moduleParams.questName
@@ -1140,10 +1118,6 @@ export function displayQuestion(nextElement) {
   //move to the next question...
   nextElement.classList.add("active");
 
-  // FINALLY...  update the tree in localForage...
-  // First let's try NOT waiting for the function to return.
-  //updateTree();
-
   localStore({})
 
   questionQueue.ptree();
@@ -1304,11 +1278,6 @@ export function getSelected(questionElement) {
   rv2 = rv2.filter((x) => x.value.length > 0);
   rv3 = rv3.filter((x) => x.hasAttribute("checked"));
 
-  // rv = rv.filter(x =>
-  //   x.type == "radio" || x.type == "checkbox" || x.type == "hidden"
-  //     ? x.checked
-  //     : x.value.length > 0
-  // );
 
   // we may need to guarentee that the hidden comes last.
   rv1 = rv1.concat(rv2);

--- a/replace2.js
+++ b/replace2.js
@@ -35,21 +35,21 @@ let reduceObj = (obj) => {
   }, "").trim()
 }
 
-transform.render = async (obj, divId, previousResults = {}) => {
-  moduleParams.renderObj = obj;
+transform.render = async (questParameters, divId, previousResults = {}) => {
+  moduleParams.renderObj = questParameters;
   moduleParams.previousResults = previousResults;
-  moduleParams.soccer = obj.soccer;
+  moduleParams.soccer = questParameters.soccer;
   rootElement = divId;
   let contents = "";
 
   // allow the client to reset the tree...
 
-  if (obj.text) contents = obj.text;
+  if (questParameters.text) contents = questParameters.text;
 
-  if (obj.url) {
-    contents = await (await fetch(obj.url)).text();
+  if (questParameters.url) {
+    contents = await (await fetch(questParameters.url)).text();
     moduleParams.config = contents
-    if (obj.activate) {
+    if (questParameters.activate) {
       const link = document.createElement("link");
       link.rel = "stylesheet";
       link.href = "https://episphere.github.io/quest/ActiveLogic.css";
@@ -96,7 +96,7 @@ transform.render = async (obj, divId, previousResults = {}) => {
 
   contents = contents.replace(/\/\*.*\*\//g, "");
   contents = contents.replace(/\/\/.*/g, "");
-  // contents = contents.replace(/\[DISPLAY IF .*\]/gms, "");
+
   let nameRegex = new RegExp(/{"name":"(\w*)"}/);
   if (nameRegex.test(contents)) {
     contents = contents.replace(/{"name":"(\w*)"}/, fQuestName);
@@ -140,8 +140,7 @@ transform.render = async (obj, divId, previousResults = {}) => {
     questArgs,
     questText
   ) {
-    // questText = questText.replace(/\/\*[\s\S]+\*\//g, "");
-    // questText = questText.replace(/\/\/.*\n/g, "");
+    
     questText = questText.replace(/\u001f/g, "\n");
     questText = questText.replace(/(?:\r\n|\r|\n)/g, "<br>");
     questText = questText.replace(/\[_#\]/g, "");
@@ -889,26 +888,27 @@ transform.render = async (obj, divId, previousResults = {}) => {
 
   // wait for the objects to be retrieved,
   // then reset the tree.
-  await fillForm(obj.retrieve);
+  await fillForm(questParameters.retrieve);
 
   // get the tree from either 1) the client or 2) localforage..
   // either way, we always use the version in LF...
-  if (obj.treeJSON) {
-    questionQueue.loadFromJSON(obj.treeJSON)
-  } else {
-    await localforage.getItem(questName + ".treeJSON").then((tree) => {
-      // if this is the first time the user attempt
-      // the questionnaire, the tree will not be in
-      // the localForage...
-      if (tree) {
-        questionQueue.loadFromVanillaObject(tree);
-      } else {
-        questionQueue.clear();
-      }
-      // not sure this is needed.  resetTree set it active...
-      setActive(questionQueue.currentNode.value);
-    });
-  }
+  	if (questParameters.tree) {
+      	questionQueue.loadFromJSON(questParameters.tree)
+  	} 
+	else {
+    	await moduleParams.localforage.getItem("_treeJSON").then((tree) => {
+
+			if (tree) {
+				questionQueue.loadFromVanillaObject(tree);
+			} 
+			else {
+				questionQueue.clear();
+			}
+		
+			// not sure this is needed.  resetTree set it active...
+			setActive(questionQueue.currentNode.value);
+    	});
+	}
 
   
 


### PR DESCRIPTION
This PR addresses the following Issues:
* N/A
-----
Background Details
* Quest shouldn't be trying to reload the form when we submit, it should be handled by whatever is calling Quest if that functionality is needed
-----
Technical Changes
* removed commented out code
* removed functions `updateTree` and `updateTreeInLocalForage`
* replaced `obj` with meaningful variable name
* updated logic in `render()` to grab local forage tree from new location
* updated Quest input parameter from `treeJSON` to `tree`
