### PR TITLE
update ssn validation (Safari 16.3 & prior compatibility)

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -188,8 +188,10 @@ function validate_text(inputElement) {
 
     // validate a SSN...
     if (inputElement.classList.contains("SSN")) {
-        if (!/^(?!9|000|666)(\d)\d{2}-?(?!00)\d{2}-?(?!0000)\d{4}(?<!\1{3}-?\1{2}-?\1{4}?)/.test(inputElement.value) ||
-        ["078-05-1120","219-09-9999"].includes(inputElement.value) ) {
+        // Remove dashes if they exist. Do not clean further (too permissive).
+        const normalizedSSN = inputElement.value.replace(/^(\d{3})-?(\d{2})-?(\d{4})$/, '$1$2$3');
+        if (!/^(?!9|000|666)[0-8]\d{2}(?!00)\d{2}(?!0000)\d{4}$/.test(normalizedSSN) ||
+            ["078051120","219099999","111111111","333333333"].includes(normalizedSSN) ) {
             validationError(inputElement, "Please enter a valid Social Security Number in this format: 999-99-9999.")
             return
         } else {

--- a/validate.js
+++ b/validate.js
@@ -188,10 +188,7 @@ function validate_text(inputElement) {
 
     // validate a SSN...
     if (inputElement.classList.contains("SSN")) {
-        // Remove dashes if they exist. Do not clean further (too permissive).
-        const normalizedSSN = inputElement.value.replace(/^(\d{3})-?(\d{2})-?(\d{4})$/, '$1$2$3');
-        if (!/^(?!9|000|666)[0-8]\d{2}(?!00)\d{2}(?!0000)\d{4}$/.test(normalizedSSN) ||
-            ["078051120","219099999","111111111","333333333"].includes(normalizedSSN) ) {
+        if (!/^(?!9|000|666)(?!111-?11-?1111|333-?33-?3333|078-?05-?1120|219-?09-?9999)\d{3}-?(?!00)\d{2}-?(?!0000)\d{4}/gm.test(inputElement.value)) {
             validationError(inputElement, "Please enter a valid Social Security Number in this format: 999-99-9999.")
             return
         } else {


### PR DESCRIPTION
Update validation.js SSN handling for Safari 16.3 and prior compatibility.

@danielruss @anthonypetersen Please advise on this when you can.

**Existing RegExp rules:**
(1) Does not start with ‘9’, ‘000’, or ‘666’.
(2) Capture two more digits. Ensure they don’t match the first digit.
(3) optional dash (‘-‘)
(4) Ensure middle two are digits. Cannot be ’00’
(5) Optional dash.
(6) Ensure last four are digits. Cannot be ‘0000’
(7) Ensure it isn’t a single number repeated throughout.

**Problem:**
This part has support issues ‘negative lookbehind,’ unsupported in Safari 16.3 and prior. Based on DataDog logs, this is impacting several participants/week due to not updating their browsers.
Here's the unsupported part: (?<!\1{3}-?\1{2}-?\1{4}?) causing a syntax error (the Quest import fails).

**Error Traced back to the validate function:** 
Note: This works in Chrome, Firefox, and Safari versions 16.4+, it was unsupported through Safari v16.3 -- we appear to have many participants using Safari versions as far back as 15.6 from the data I've seen. In unsupported versions, the lookbehind creates a syntax error and the Quest import fails.
<img width="1297" alt="Screenshot 2024-03-12 at 5 04 16 PM" src="https://github.com/episphere/quest/assets/93854858/2f022be9-6a90-4931-ae09-ed4a9ff773e7">

 
**Browser support chart:**
https://caniuse.com/?search=RegExp%20lookbehind%20assertions


**Updated handling:**
(1) Handle all steps above except 7.

•Clean dashes at specific locations for simplified checking of all conditions. Do not clean further (that would be too permissive).
const normalizedSSN = inputElement.value.replace(/^(\d{3})-?(\d{2})-?(\d{4})$/, '$1$2$3');

•Use Daniel’s formatting check, adapted to the normalizedSSN
!/^(?!9|000|666)[0-8]\d{2}(?!00)\d{2}(?!0000)\d{4}$/.test(normalizedSSN)

(2) Handle & adapt step 7 from existing rules to match Connect PWA and cloud function validation. 
•Integrate Daniel and Tony’s rules for SSNs "078051120", "219099999", "111111111", and “333333333"
•Omit handling of repeating numbers 2, 4, 5, 6, 7, 8 to match validation in PWA and SSN cloud function