### PR TITLE
Add back leading zero in month value when input type='month' is not supported (Safari MacOS X & Firefox) so validation triggers

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -126,14 +126,15 @@ function validate_month(inputElement) {
     let before_min_date = minDate && selectedDate < minDate
     let after_max_date = maxDate && selectedDate > maxDate
 
+    // When input type='month' is supported, out of range values aren't selectable on the calendar.
+    // validationError shows when type="month" is not supported. Match expected text input format.
     if (before_min_date) {
-        validationError(inputElement, `Date must be after ${minDate.getUTCMonth() + 1}/${minDate.getUTCFullYear()}`)
+        validationError(inputElement, `Date must be after ${minDate.getUTCFullYear()}-${(minDate.getUTCMonth() + 1).toString().padStart(2, '0')}`)
     } else if (after_max_date) {
-        validationError(inputElement, `Date must be before ${maxDate.getUTCMonth() + 1}/${maxDate.getUTCFullYear()}`)
+        validationError(inputElement, `Date must be before ${maxDate.getUTCFullYear()}-${(maxDate.getUTCMonth() + 1).toString().padStart(2, '0')}`)
     } else {
         clearValidationError(inputElement)
     }
-
 }
 
 function validate_date(inputElement) {


### PR DESCRIPTION
@danielruss @anthonypetersen please take a look at this when you have some time. Thanks!

Safari for Mac OS X and Firefox don't support input type='month' (Note: Safari for iOS does support 'month').
When unsupported, browsers default to input type='text', which displays as an empty text box.

Issue: For month values 0-9, the leading zero is stripped from the month value when the browser does not support the month type.
That caused a Date object parsing error in Date objects and validation, bypassing date validation.

---
<img width="1062" alt="Screenshot 2024-03-21 at 12 45 55 PM" src="https://github.com/episphere/quest/assets/93854858/b6860563-f415-46e9-bfd4-d16cde596d4d">

---

We found this issue working backward from a recent ServiceNow ticket in which a participant entered a future date that would've been caught in validation.

This PR:
• Checks for input type='month' support (flexible if more browsers support 'month' input in the future).
• Adds placeholder text 'YYYY-MM' to guide the user when the 'month' input type is not supported.
• Adds back the leading zero in cases where the month value was stripped to a single digit.
• Updates error messaging to coincide with the desired text input format.