### PR TITLE
in-survey accessibility enhancements

### DIFF
--- a/ActiveLogic.css
+++ b/ActiveLogic.css
@@ -25,9 +25,6 @@
    margin-bottom: 1em;
 }
 
-/* .question p strong {
-  font-weight: bold !important;
-} */
 .question.active p b {
   font-family: 'Monserrat', sans-serif;
   font-weight: bold;
@@ -53,172 +50,281 @@ input[type="text"] {
   flex-grow: 1;
 }
 
-
-/* CSS for grids... */
+/* CSS for grids... '.quest-grid' impacts all grids and list grids. '.quest-grid.table-layout' (increased specificity) handles the new table-based grids. */
+/* CSS for ALL (list and table) Grids... */
 .quest-grid {
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
   font-family: Arial, Helvetica, sans-serif;
-  font-size: 1rem;
+  font-size: medium;
+  margin-top: 10px;
 }
 
-.quest-grid tr {
-  width: auto;
-  display: table-row !important;
-}
-
-.quest-grid th, .quest-grid td {
-  padding: 10px;
+.quest-grid * {
+  padding: 4px;
   text-align: center;
-  vertical-align: middle;
-  height: 70px;
-  position: relative;
 }
 
-.quest-grid th.nr, .quest-grid td.nr {
-  font-weight: bold;
-  text-align: left;
+/* CSS for LIST grids... TODO: the list CSS is deprecated. */
+.quest-grid {
+  display: grid;
+  grid-template-columns: auto repeat(12,minmax(0px,auto));
+  overflow-x: auto;
+  gap: 1px;
+  overflow-y: visible;
 }
 
-.quest-grid td {
-  width: auto;
-  position: relative;
-  min-height: 70px;
-  padding: 10px;
+.quest-grid > .nr {
+  grid-column-start: 1;
+  text-align: start;
+  align-self: center;
 }
 
-.quest-grid .custom-label {
-  background-color: #f4f4f4;
-  border-radius: 4px;
-  text-align: center;
-  cursor: pointer;
-  overflow: hidden;
-  white-space: nowrap;
-  text-indent: 100%;
-  color: transparent;
-}
-
-.quest-grid .custom-label hover {
-  color: #e6e6e6;
-}
-
-.quest-grid input[type="radio"] {
-  display: none;
-}
-
-.quest-grid input[type="radio"]:checked + .custom-label {
-  background-color: #205c84;
-  color: transparent;
-}
-
-/* Styles for when the radio button is checked */
-.quest-grid input[type="radio"]:checked + .custom-label::after {
-  content: '\2713'; /* Unicode character for checkmark */
-  color: #ffbc24;
-  font-size: 36px;
-  position: absolute;
-  left: 35%;
-  top: 50%;
-  transform: translate(-75%, -50%);
+ul.quest-grid{
+  padding: 0px;
+  list-style-type: none;
+  min-width: min-content;
 }
 
 @media screen and (min-width: 576px) {
-  /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
-  .quest-grid th:first-child, .quest-grid td:first-child {
-    width: 35%;
-    font-weight: bold;
+  ul.quest-grid input{
+      display: inline;
+      height: 1rem;
+  }
+  ul.quest-grid label{
+      display: none;
   }
 }
-
 
 /** 
 I chose 576px because this matches the default breakpoint
 for bootstrap -xs
 **/
 @media screen and (max-width: 576px) {
-  .quest-grid, .quest-grid thead, .quest-grid tbody, .quest-grid th, .quest-grid td, .quest-grid tr { 
+  .quest-grid {
+      display: block;
+      width:100%;
+  }
+  ul.quest-grid {
+      min-width: min-content;
+      list-style-type: none;
+      text-align: left;
+  }
+  ul.quest-grid > li {
+      margin-top: 2px;
+  }
+
+  li {
+    list-style-type: none;
+  }
+
+  ul.quest-grid .hr {
+      display: none;
+  }
+
+  ul.quest-grid li.nr {
+      display: block;
+  }
+
+  ul.quest-grid li.nr:not(:first-child){
+      padding-top: 10px;
+  }   
+}
+
+/* CSS for TABLE grids... */
+.quest-grid.table-layout {
+  display: inline-table;
+}
+
+.quest-grid.table-layout tr {
+  width: auto;
+  display: table-row;
+}
+
+.quest-grid.table-layout th, .quest-grid.table-layout td {
+  padding: 5px;
+  text-align: center;
+  vertical-align: middle;
+  height: 50px;
+  position: relative;
+  background-color: transparent;
+  border: none;
+}
+
+.quest-grid.table-layout th.nr, .quest-grid.table-layout td.nr {
+  font-weight: bold;
+  text-align: left;
+}
+
+.quest-grid.table-layout input[type="radio"] {
+  display: none;
+}
+
+/* Additional styles to ensure the label is large enough to comfortably contain the circles */
+.quest-grid.table-layout .custom-label {
+  position: relative;
+  height: 50px;
+  min-width: 50px;
+  color: transparent;
+  background-color: transparent;
+  cursor: pointer;
+  border: none;
+  outline: none;
+}
+
+/* Styling for the custom label to always have an unfilled circle */
+.quest-grid.table-layout .custom-label::before {
+  content: '';
+  display: block;
+  width: 26px;
+  height: 26px;
+  border: 2px solid #cccccc;
+  border-radius: 50%; /* Circle */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: transparent;
+}
+
+.quest-grid.table-layout .custom-label:hover {
+  background-color: transparent;
+  border: none;
+  outline: none;
+}
+
+/* Hover effect for the label */
+.quest-grid .custom-label:hover::before {
+  border-color: #1c5d86;
+  box-shadow: 0 0 8px #ccc;
+}
+
+/* Styling for when the radio button is checked */
+.quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
+  content: '';
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%; /* Circle */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #327ABB;
+}
+
+.quest-grid.table-layout input[type="radio"]:checked + .custom-label {
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+@media screen and (min-width: 576px) {
+  /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
+  .quest-grid.table-layout th:first-child, .quest-grid td:first-child {
+    width: 35%;
+    font-weight: bold;
+  }
+}
+
+/** 
+I chose 576px because this matches the default breakpoint
+for bootstrap -xs
+**/
+@media screen and (max-width: 576px) {
+  .quest-grid.table-layout, .quest-grid.table-layout thead, .quest-grid.table-layout td  { 
     display: block;
   }
 
-  .quest-grid thead tr { 
+  .quest-grid.table-layout .custom-label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: transparent;
+    cursor: pointer;
+    display: block;
+  }
+
+  .quest-grid.table-layout tbody {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .quest-grid.table-layout thead tr { 
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
 
-  .quest-grid tr { 
+  .quest-grid.table-layout tr { 
     display: flex;
-    flex-direction: row;
-    justify-content: space-between; /* Distribute space between header and label */
-    border: 1px solid #ccc;
+    flex-direction: column;
+    border: 1px solid #a3a3a3;
     border-radius: 4px;
-    margin-top: 10px;
-    padding: 2px;
-  }
-
-  .quest-grid th {
+    margin-top: 10px; 
     padding: 5px;
-    min-height: auto; /* Allow expansion for long questions/headers */
-    height: auto;
-    display: block; /* Stack cells vertically in smaller views */
+  }
+
+  .quest-grid.table-layout td { 
+    display: block;
     width: 100%;
-    font-size: 14px;
-    word-wrap: break-word; /* Allow long words to be broken and wrapped */
-    padding: 10px 0;
-  }
-
-  .quest-grid td { 
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    position: relative;
-    padding: 5px;
-    min-height: 70px;
-    width: 100%;
-  }
-
-  .quest-grid td::before {
-    content: attr(data-header);
-    font-size: 16px;
-    color: #333;
-    flex: 1;  
-    padding-right: 10px;  
-    white-space: normal; 
-    overflow: hidden;  
-    text-overflow: ellipsis; 
-    max-width: 60%;  
-    text-align: left;
-  }
-
-  .quest-grid .custom-label {
-    height: 60px;
-    line-height: 60px;
-    width: 30%;
-    margin-left: 33%;
-    background-color: #f4f4f4;
-    border-radius: 4px;
+    margin-bottom: 3px;
     text-align: center;
+    min-height: 100px;
+    height: auto;
+    padding: 5px;
     cursor: pointer;
-    overflow: hidden;
-    text-indent: 100%;
-    white-space: nowrap;
+    background-color: #f4f4f4;
+    color: #333;
+    font-size: 16px;
+    border-radius: 4px;
+    position: relative;
   }
 
-  .quest-grid input[type="radio"] {
+  .quest-grid.table-layout td:hover {
+    background-color: #e0e0e0;
+    color: #333;
+  }
+
+  .quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
     display: none;
   }
 
-  .quest-grid input[type="radio"]:checked + .custom-label {
-    background-color: #205c84;
+  .quest-grid.table-layout .custom-label::before {
+    display: none;
   }
 
-  .quest-grid input[type="radio"]:checked + .custom-label::after {
-    content: '\2713'; /* Unicode character for checkmark */
-    color: #ffbc24;
-    font-size: 36px;
+  .quest-grid.table-layout td input[type="radio"]:checked + .custom-label {
     position: absolute;
-    left: 78%;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #327ABB;
+    color: white;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+    padding: 0 5px;
+    box-sizing: border-box;
+    z-index: 1;
+    text-transform: none;
+    line-height: normal;
+  }
+
+ .quest-grid.table-layout td::before {
+    content: attr(data-header);
+    font-size: 16px;
+    color: #333;
+    position: absolute;
     top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    padding: 0 3px;
   }
 }

--- a/ActiveLogic.css
+++ b/ActiveLogic.css
@@ -45,6 +45,28 @@
   width: auto;
 }
 
+#loadingIndicator {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 9999;
+}
+
+.spinner {
+  border: 16px solid #f3f3f3;
+  border-top: 16px solid #3498db;
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
 .freeresponse textarea,
 input[type="text"] {
   flex-grow: 1;

--- a/ActiveLogic.css
+++ b/ActiveLogic.css
@@ -1,5 +1,5 @@
 #questionnaire {
-  font-family: Ariel, sans-serif;
+  font-family: Arial, sans-serif;
   height: 70%;
   border: solid 2px black;
   padding: 20px;
@@ -11,26 +11,27 @@
 
 #thankYou,
 .question {
-  margin: 10px 0px;
+  margin: 5px 0px;
   display: none;
 }
 
 #thankYou.active,
 .question.active {
+  padding-top: 5px;
   display: block;
 }
 
-/* .previous {
-  float: left;
+.question p { 
+   margin-bottom: 1em;
 }
 
-.next {
-  float: right;
-}
-
-.submit {
-  float: right;
+/* .question p strong {
+  font-weight: bold !important;
 } */
+.question.active p b {
+  font-family: 'Monserrat', sans-serif;
+  font-weight: bold;
+}
 
 /* this is an answer with a text area...*/
 
@@ -54,44 +55,79 @@ input[type="text"] {
 
 
 /* CSS for grids... */
-.quest-grid{
+.quest-grid {
   width: 100%;
-  display: grid;
-  grid-template-columns: auto repeat(12,minmax(0px,auto));
-
-  font-family:Arial, Helvetica, sans-serif;
-  font-size: medium;
-  overflow-x: auto;
-  gap: 1px;
-  overflow-y: visible;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1rem;
 }
 
-.quest-grid * {
-  padding: 4px;
+.quest-grid tr {
+  width: auto;
+  display: table-row !important;
+}
+
+.quest-grid th, .quest-grid td {
+  padding: 10px;
   text-align: center;
+  vertical-align: middle;
+  height: 70px;
+  position: relative;
 }
 
-.quest-grid > .nr {
-  grid-column-start: 1;
-  text-align: start;
-  align-self: center;
+.quest-grid th.nr, .quest-grid td.nr {
+  font-weight: bold;
+  text-align: left;
 }
 
-ul.quest-grid{
-  padding: 0px;
-  list-style-type: none;
-  min-width: min-content;
+.quest-grid td {
+  width: auto;
+  position: relative;
+  min-height: 70px;
+  padding: 10px;
 }
 
+.quest-grid .custom-label {
+  background-color: #f4f4f4;
+  border-radius: 4px;
+  text-align: center;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  text-indent: 100%;
+  color: transparent;
+}
 
+.quest-grid .custom-label hover {
+  color: #e6e6e6;
+}
+
+.quest-grid input[type="radio"] {
+  display: none;
+}
+
+.quest-grid input[type="radio"]:checked + .custom-label {
+  background-color: #205c84;
+  color: transparent;
+}
+
+/* Styles for when the radio button is checked */
+.quest-grid input[type="radio"]:checked + .custom-label::after {
+  content: '\2713'; /* Unicode character for checkmark */
+  color: #ffbc24;
+  font-size: 36px;
+  position: absolute;
+  left: 35%;
+  top: 50%;
+  transform: translate(-75%, -50%);
+}
 
 @media screen and (min-width: 576px) {
-  ul.quest-grid input{
-      display: inline;
-      height: 1rem;
-  }
-  ul.quest-grid label{
-      display: none;
+  /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
+  .quest-grid th:first-child, .quest-grid td:first-child {
+    width: 35%;
+    font-weight: bold;
   }
 }
 
@@ -101,36 +137,88 @@ I chose 576px because this matches the default breakpoint
 for bootstrap -xs
 **/
 @media screen and (max-width: 576px) {
-  .quest-grid {
-      display: block;
-      width:100%;
-  }
-  ul.quest-grid{
-      min-width: min-content;
-      list-style-type: none;
-      text-align: left;
-  }
-  ul.quest-grid > li {
-      margin-top: 2px;
+  .quest-grid, .quest-grid thead, .quest-grid tbody, .quest-grid th, .quest-grid td, .quest-grid tr { 
+    display: block;
   }
 
-  li {
-    list-style-type: none;
+  .quest-grid thead tr { 
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
   }
 
-  ul.quest-grid .hr {
-      display: none;
+  .quest-grid tr { 
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between; /* Distribute space between header and label */
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-top: 10px;
+    padding: 2px;
   }
 
-  ul.quest-grid li.nr {
-      display: block;
+  .quest-grid th {
+    padding: 5px;
+    min-height: auto; /* Allow expansion for long questions/headers */
+    height: auto;
+    display: block; /* Stack cells vertically in smaller views */
+    width: 100%;
+    font-size: 14px;
+    word-wrap: break-word; /* Allow long words to be broken and wrapped */
+    padding: 10px 0;
   }
 
-  ul.quest-grid li.nr:not(:first-child){
-      padding-top: 10px;
+  .quest-grid td { 
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    padding: 5px;
+    min-height: 70px;
+    width: 100%;
   }
 
+  .quest-grid td::before {
+    content: attr(data-header);
+    font-size: 16px;
+    color: #333;
+    flex: 1;  
+    padding-right: 10px;  
+    white-space: normal; 
+    overflow: hidden;  
+    text-overflow: ellipsis; 
+    max-width: 60%;  
+    text-align: left;
+  }
 
+  .quest-grid .custom-label {
+    height: 60px;
+    line-height: 60px;
+    width: 30%;
+    margin-left: 33%;
+    background-color: #f4f4f4;
+    border-radius: 4px;
+    text-align: center;
+    cursor: pointer;
+    overflow: hidden;
+    text-indent: 100%;
+    white-space: nowrap;
+  }
 
-    
+  .quest-grid input[type="radio"] {
+    display: none;
+  }
+
+  .quest-grid input[type="radio"]:checked + .custom-label {
+    background-color: #205c84;
+  }
+
+  .quest-grid input[type="radio"]:checked + .custom-label::after {
+    content: '\2713'; /* Unicode character for checkmark */
+    color: #ffbc24;
+    font-size: 36px;
+    position: absolute;
+    left: 78%;
+    top: 50%;
+  }
 }

--- a/Default.css
+++ b/Default.css
@@ -5,170 +5,282 @@ input[type="checkbox"] + label {
 
 
 /* CSS for grids... note: this has been duplicated from ActiveLogic.css. I haven't had time to check why, so I'm continuing the process for now. */
+/* '.quest-grid' impacts all grids and list grids. '.quest-grid.table-layout' (increased specificity) handles the new table-based grids. */
+/* TODO: the list CSS is deprecated. This can be removed once the table-layout structure is in production */
+/* CSS for ALL (list and table) Grids... */
 .quest-grid {
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
   font-family: Arial, Helvetica, sans-serif;
-  font-size: 1rem;
+  font-size: medium;
+  margin-top: 10px;
 }
 
-.quest-grid tr {
-  width: auto;
-  display: table-row !important;
-}
-
-.quest-grid th, .quest-grid td {
-  padding: 10px;
+.quest-grid * {
+  padding: 4px;
   text-align: center;
-  vertical-align: middle;
-  height: 70px;
-  position: relative;
 }
 
-.quest-grid th.nr, .quest-grid td.nr {
-  font-weight: bold;
-  text-align: left;
+/* CSS for LIST grids... TODO: the list CSS is deprecated. */
+.quest-grid {
+  display: grid;
+  grid-template-columns: auto repeat(12,minmax(0px,auto));
+  overflow-x: auto;
+  gap: 1px;
+  overflow-y: visible;
 }
 
-.quest-grid td {
-  width: auto;
-  position: relative;
-  min-height: 70px;
-  padding: 10px;
+.quest-grid > .nr {
+  grid-column-start: 1;
+  text-align: start;
+  align-self: center;
 }
 
-.quest-grid .custom-label {
-  background-color: #f4f4f4;
-  border-radius: 4px;
-  text-align: center;
-  cursor: pointer;
-  overflow: hidden;
-  white-space: nowrap;
-  text-indent: 100%;
-  color: transparent;
-}
-
-.quest-grid .custom-label hover {
-  color: #e6e6e6;
-}
-
-.quest-grid input[type="radio"] {
-  display: none;
-}
-
-.quest-grid input[type="radio"]:checked + .custom-label {
-  background-color: #205c84;
-  color: transparent;
-}
-
-/* Styles for when the radio button is checked */
-.quest-grid input[type="radio"]:checked + .custom-label::after {
-  content: '\2713'; /* Unicode character for checkmark */
-  color: #ffbc24;
-  font-size: 36px;
-  position: absolute;
-  left: 35%;
-  top: 50%;
-  transform: translate(-75%, -50%);
+ul.quest-grid{
+  padding: 0px;
+  list-style-type: none;
+  min-width: min-content;
 }
 
 @media screen and (min-width: 576px) {
-  /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
-  .quest-grid th:first-child, .quest-grid td:first-child {
-    width: 35%;
-    font-weight: bold;
+  ul.quest-grid input{
+      display: inline;
+      height: 1rem;
+  }
+  ul.quest-grid label{
+      display: none;
   }
 }
-
 
 /** 
 I chose 576px because this matches the default breakpoint
 for bootstrap -xs
 **/
 @media screen and (max-width: 576px) {
-  .quest-grid, .quest-grid thead, .quest-grid tbody, .quest-grid th, .quest-grid td, .quest-grid tr { 
+  .quest-grid {
+      display: block;
+      width:100%;
+  }
+  ul.quest-grid {
+      min-width: min-content;
+      list-style-type: none;
+      text-align: left;
+  }
+  ul.quest-grid > li {
+      margin-top: 2px;
+  }
+
+  li {
+    list-style-type: none;
+  }
+
+  ul.quest-grid .hr {
+      display: none;
+  }
+
+  ul.quest-grid li.nr {
+      display: block;
+  }
+
+  ul.quest-grid li.nr:not(:first-child){
+      padding-top: 10px;
+  }   
+}
+
+/* CSS for TABLE grids... */
+.quest-grid.table-layout {
+  display: inline-table;
+}
+
+.quest-grid.table-layout tr {
+  width: auto;
+  display: table-row;
+}
+
+.quest-grid.table-layout th, .quest-grid.table-layout td {
+  padding: 5px;
+  text-align: center;
+  vertical-align: middle;
+  height: 50px;
+  position: relative;
+  background-color: transparent;
+  border: none;
+}
+
+.quest-grid.table-layout th.nr, .quest-grid.table-layout td.nr {
+  font-weight: bold;
+  text-align: left;
+}
+
+.quest-grid.table-layout input[type="radio"] {
+  display: none;
+}
+
+/* Additional styles to ensure the label is large enough to comfortably contain the circles */
+.quest-grid.table-layout .custom-label {
+  position: relative;
+  height: 50px;
+  min-width: 50px;
+  color: transparent;
+  background-color: transparent;
+  cursor: pointer;
+  border: none;
+  outline: none;
+}
+
+/* Styling for the custom label to always have an unfilled circle */
+.quest-grid.table-layout .custom-label::before {
+  content: '';
+  display: block;
+  width: 26px;
+  height: 26px;
+  border: 2px solid #cccccc;
+  border-radius: 50%; /* Circle */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: transparent;
+}
+
+.quest-grid.table-layout .custom-label:hover {
+  background-color: transparent;
+  border: none;
+  outline: none;
+}
+
+/* Hover effect for the label */
+.quest-grid .custom-label:hover::before {
+  border-color: #1c5d86;
+  box-shadow: 0 0 8px #ccc;
+}
+
+/* Styling for when the radio button is checked */
+.quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
+  content: '';
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%; /* Circle */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #327ABB;
+}
+
+.quest-grid.table-layout input[type="radio"]:checked + .custom-label {
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+@media screen and (min-width: 576px) {
+  /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
+  .quest-grid.table-layout th:first-child, .quest-grid td:first-child {
+    width: 35%;
+    font-weight: bold;
+  }
+}
+
+/** 
+I chose 576px because this matches the default breakpoint
+for bootstrap -xs
+**/
+@media screen and (max-width: 576px) {
+  .quest-grid.table-layout, .quest-grid.table-layout thead, .quest-grid.table-layout td  { 
     display: block;
   }
 
-  .quest-grid thead tr { 
+  .quest-grid.table-layout .custom-label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: transparent;
+    cursor: pointer;
+    display: block;
+  }
+
+  .quest-grid.table-layout tbody {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .quest-grid.table-layout thead tr { 
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
 
-  .quest-grid tr { 
+  .quest-grid.table-layout tr { 
     display: flex;
-    flex-direction: row;
-    justify-content: space-between; /* Distribute space between header and label */
-    border: 1px solid #ccc;
+    flex-direction: column;
+    border: 1px solid #a3a3a3;
     border-radius: 4px;
-    margin-top: 10px;
-    padding: 2px;
-  }
-
-  .quest-grid th {
+    margin-top: 10px; 
     padding: 5px;
-    min-height: auto; /* Allow expansion for long questions/headers */
-    height: auto;
-    display: block; /* Stack cells vertically in smaller views */
+  }
+
+  .quest-grid.table-layout td { 
+    display: block;
     width: 100%;
-    font-size: 14px;
-    word-wrap: break-word; /* Allow long words to be broken and wrapped */
-    padding: 10px 0;
-  }
-
-  .quest-grid td { 
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    position: relative;
-    padding: 5px;
-    min-height: 70px;
-    width: 100%;
-  }
-
-  .quest-grid td::before {
-    content: attr(data-header);
-    font-size: 16px;
-    color: #333;
-    flex: 1;  
-    padding-right: 10px;  
-    white-space: normal; 
-    overflow: hidden;  
-    text-overflow: ellipsis; 
-    max-width: 60%;  
-    text-align: left;
-  }
-
-  .quest-grid .custom-label {
-    height: 60px;
-    line-height: 60px;
-    width: 30%;
-    margin-left: 33%;
-    background-color: #f4f4f4;
-    border-radius: 4px;
+    margin-bottom: 3px;
     text-align: center;
+    min-height: 100px;
+    height: auto;
+    padding: 5px;
     cursor: pointer;
-    overflow: hidden;
-    text-indent: 100%;
-    white-space: nowrap;
+    background-color: #f4f4f4;
+    color: #333;
+    font-size: 16px;
+    border-radius: 4px;
+    position: relative;
   }
 
-  .quest-grid input[type="radio"] {
+  .quest-grid.table-layout td:hover {
+    background-color: #e0e0e0;
+    color: #333;
+  }
+
+  .quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
     display: none;
   }
 
-  .quest-grid input[type="radio"]:checked + .custom-label {
-    background-color: #205c84;
+  .quest-grid.table-layout .custom-label::before {
+    display: none;
   }
 
-  .quest-grid input[type="radio"]:checked + .custom-label::after {
-    content: '\2713'; /* Unicode character for checkmark */
-    color: #ffbc24;
-    font-size: 36px;
+  .quest-grid.table-layout td input[type="radio"]:checked + .custom-label {
     position: absolute;
-    left: 78%;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #327ABB;
+    color: white;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+    padding: 0 5px;
+    box-sizing: border-box;
+    z-index: 1;
+    text-transform: none;
+    line-height: normal;
+  }
+
+ .quest-grid.table-layout td::before {
+    content: attr(data-header);
+    font-size: 16px;
+    color: #333;
+    position: absolute;
     top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    padding: 0 3px;
   }
 }

--- a/Default.css
+++ b/Default.css
@@ -4,44 +4,80 @@ input[type="checkbox"] + label {
 }
 
 
-/* CSS for grids... */
-.quest-grid{
+/* CSS for grids... note: this has been duplicated from ActiveLogic.css. I haven't had time to check why, so I'm continuing the process for now. */
+.quest-grid {
   width: 100%;
-  display: grid;
-  grid-template-columns: auto repeat(12,minmax(0px,auto));
-
-  font-family:Arial, Helvetica, sans-serif;
-  font-size: small;
-  overflow-x: auto;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1rem;
 }
 
-.quest-grid > .nr {
-  grid-column-start: 1;
-  text-align: start;
+.quest-grid tr {
+  width: auto;
+  display: table-row !important;
 }
 
-ul.quest-grid{
-  padding: 0px;
-  min-width: min-content;
-  list-style-type: none;
+.quest-grid th, .quest-grid td {
+  padding: 10px;
   text-align: center;
+  vertical-align: middle;
+  height: 70px;
+  position: relative;
 }
 
-ul.quest-grid:li{
-  padding: 0px;
-  min-width: min-content;
-  list-style-type: none;
+.quest-grid th.nr, .quest-grid td.nr {
+  font-weight: bold;
+  text-align: left;
+}
+
+.quest-grid td {
+  width: auto;
+  position: relative;
+  min-height: 70px;
+  padding: 10px;
+}
+
+.quest-grid .custom-label {
+  background-color: #f4f4f4;
+  border-radius: 4px;
   text-align: center;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  text-indent: 100%;
+  color: transparent;
 }
 
+.quest-grid .custom-label hover {
+  color: #e6e6e6;
+}
 
+.quest-grid input[type="radio"] {
+  display: none;
+}
+
+.quest-grid input[type="radio"]:checked + .custom-label {
+  background-color: #205c84;
+  color: transparent;
+}
+
+/* Styles for when the radio button is checked */
+.quest-grid input[type="radio"]:checked + .custom-label::after {
+  content: '\2713'; /* Unicode character for checkmark */
+  color: #ffbc24;
+  font-size: 36px;
+  position: absolute;
+  left: 35%;
+  top: 50%;
+  transform: translate(-75%, -50%);
+}
 
 @media screen and (min-width: 576px) {
-  ul.quest-grid input{
-      display: inline;
-  }
-  ul.quest-grid label{
-      display: none;
+  /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
+  .quest-grid th:first-child, .quest-grid td:first-child {
+    width: 35%;
+    font-weight: bold;
   }
 }
 
@@ -51,36 +87,88 @@ I chose 576px because this matches the default breakpoint
 for bootstrap -xs
 **/
 @media screen and (max-width: 576px) {
-  .quest-grid {
-      display: block;
-      width:100%;
-  }
-  ul.quest-grid{
-      min-width: min-content;
-      list-style-type: none;
-      text-align: left;
+  .quest-grid, .quest-grid thead, .quest-grid tbody, .quest-grid th, .quest-grid td, .quest-grid tr { 
+    display: block;
   }
 
-  li {
-    list-style-type: none;
+  .quest-grid thead tr { 
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
   }
 
-  ul.quest-grid .hr {
-      display: none;
+  .quest-grid tr { 
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between; /* Distribute space between header and label */
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-top: 10px;
+    padding: 2px;
   }
 
-  ul.quest-grid li.nr {
-      display: block;
+  .quest-grid th {
+    padding: 5px;
+    min-height: auto; /* Allow expansion for long questions/headers */
+    height: auto;
+    display: block; /* Stack cells vertically in smaller views */
+    width: 100%;
+    font-size: 14px;
+    word-wrap: break-word; /* Allow long words to be broken and wrapped */
+    padding: 10px 0;
   }
 
-  ul.quest-grid li.nr:not(:first-child){
-      padding-top: 10px;
+  .quest-grid td { 
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    padding: 5px;
+    min-height: 70px;
+    width: 100%;
   }
 
-  ul.quest-grid li label {
-      display: unset;
-      padding-left: 5px;
+  .quest-grid td::before {
+    content: attr(data-header);
+    font-size: 16px;
+    color: #333;
+    flex: 1;  
+    padding-right: 10px;  
+    white-space: normal; 
+    overflow: hidden;  
+    text-overflow: ellipsis; 
+    max-width: 60%;  
+    text-align: left;
   }
 
-    
+  .quest-grid .custom-label {
+    height: 60px;
+    line-height: 60px;
+    width: 30%;
+    margin-left: 33%;
+    background-color: #f4f4f4;
+    border-radius: 4px;
+    text-align: center;
+    cursor: pointer;
+    overflow: hidden;
+    text-indent: 100%;
+    white-space: nowrap;
+  }
+
+  .quest-grid input[type="radio"] {
+    display: none;
+  }
+
+  .quest-grid input[type="radio"]:checked + .custom-label {
+    background-color: #205c84;
+  }
+
+  .quest-grid input[type="radio"]:checked + .custom-label::after {
+    content: '\2713'; /* Unicode character for checkmark */
+    color: #ffbc24;
+    font-size: 36px;
+    position: absolute;
+    left: 78%;
+    top: 50%;
+  }
 }

--- a/Quest.css
+++ b/Quest.css
@@ -81,6 +81,19 @@ input[type="checkbox"].form-check-input{
   background-color: transparent;
 }
 
+/* screen reader only - accessibility helper - hide element and provide audio hints */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media only screen and (max-width: 768px) {
   input[type="number"] {
     width: 150px;

--- a/Questionnaire.css
+++ b/Questionnaire.css
@@ -1,5 +1,5 @@
 #questionnaire {
-  font-family: Ariel, sans-serif;
+  font-family: Arial, sans-serif;
   height: 70%;
   border: solid 2px black;
   padding: 20px;

--- a/Style1.css
+++ b/Style1.css
@@ -1,5 +1,5 @@
 #questionnaire {
-  font-family: Ariel, sans-serif;
+  font-family: Arial, sans-serif;
   height: 70%;
   border: solid 2px black;
   padding: 20px;

--- a/buildGrid.js
+++ b/buildGrid.js
@@ -49,10 +49,7 @@ function grid_text_displayif(original_text){
       return `<span displayif="${encodeURIComponent(p1)}" class="grid-displayif"> ${p2}</span>`
     })
   }
-  // Accessibility: Replace <br/> with </p><p> to make the text more screen reader friendly.
-  // Screen reader was reading <br/> as "Empty goup" which made navigation confusing.
-  question_text = question_text
-    .replace(/<br\/>/g, "</p><p>");
+
   return question_text;
 }
 
@@ -79,7 +76,7 @@ function buildHtmlTable(grid_obj){
       <form ${grid_obj.args} class="container question" data-grid="true" ${gridPrompt} aria-describedby="formDescription" role="form">
         <div id="formDescription" class="sr-only" aria-live="polite">Please interact with the table below to answer the questions.</div>
         <div>${grid_text_displayif(shared_text)}</div>
-        <table class="quest-grid">`;
+        <table class="quest-grid table-layout">`;
   
   // Build the table header row with the question text and response headers. Start with a placeholder for the row header.
   grid_html += '<thead class="hr" role="rowgroup"><tr><th class="nr hr"></th>';
@@ -96,10 +93,6 @@ function buildHtmlTable(grid_obj){
     const piped_question_text = grid_text_displayif(question.question_text);    
     const question_text = grid_replace_piped_variables(piped_question_text);
 
-    if (question_text.id === "D_488415137") {
-      console.log('Question:', question);
-      console.log('Displayif:', displayif, 'Question Text:', question_text)
-    }
     // Start the row for the question, then add the row header (question text)
     grid_html +=
       `<tr role="row" data-question-id="${question.id}" data-gridrow="true" aria-labelledby="qtext${question.id}" ${displayif}>
@@ -112,7 +105,7 @@ function buildHtmlTable(grid_obj){
         grid_html += `
           <td class="response" data-question-id="${question.id}" data-header="${resp.text}" role="gridcell">
             <input type="${resp.type}" name="${question.id}" id="${question.id}_${resp_index}" value="${resp.value}" data-gridcell="true" data-grid="true">
-            <label for="${question.id}_${resp_index}" id="label${question.id}_${resp_index}" class="custom-label">${resp.text} checkbox</label>
+            <label for="${question.id}_${resp_index}" id="label${question.id}_${resp_index}" class="custom-label">${resp.text}</label>
           </td>`;
     });
 
@@ -127,7 +120,7 @@ function buildHtmlTable(grid_obj){
           <button type="submit" class="previous w-100" aria-label="Back to the previous section" data-click-type="previous">Back</button>
         </div>
         <div class="col-md-6 col-sm-12">
-          <button type="reset" class="reset w-100" aria-label="Reset answer for this question" data-click-type="reset">Reset Answer</button>
+          <button type="submit" class="reset w-100" aria-label="Reset answer for this question" data-click-type="reset">Reset Answer</button>
         </div>
         <div class="col-md-3 col-sm-12">
           <button type="submit" class="next w-100" aria-label="Go to the next section" data-click-type="next">Next</button>
@@ -139,7 +132,6 @@ function buildHtmlTable(grid_obj){
   return grid_html;
 }
 
-//NOTE: This function is not used in the current implementation
 function buildHtml_og(grid_obj) {
   let grid_head =
     '<div class="d-flex align-items-center border"><div class="col">Select an answer for each row below:</div>';

--- a/buildGrid.js
+++ b/buildGrid.js
@@ -1,10 +1,12 @@
-import { moduleParams } from "./questionnaire.js";
 
 export const grid_replace_regex = /\|grid(\!|\?)*\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|/g;
 
+//NOTE: This function is not used in the current implementation
 export function firstFun(event) {
   event.preventDefault();
 }
+
+//NOTE: This function is not used in the current implementation
 export function toggle_grid(event) {
   event.preventDefault();
   let element = event.target;
@@ -38,6 +40,7 @@ function grid_replace_piped_variables(txt){
   txt = txt.replace(' <span', '&nbsp;<span')
   return txt
 }
+
 function grid_text_displayif(original_text){
   let question_text = original_text
   let dif_regex = /%displayif=([^%]+)%([^%]+)%/g
@@ -46,10 +49,15 @@ function grid_text_displayif(original_text){
       return `<span displayif="${encodeURIComponent(p1)}" class="grid-displayif"> ${p2}</span>`
     })
   }
+  // Accessibility: Replace <br/> with </p><p> to make the text more screen reader friendly.
+  // Screen reader was reading <br/> as "Empty goup" which made navigation confusing.
+  question_text = question_text
+    .replace(/<br\/>/g, "</p><p>");
   return question_text;
 }
 
-function buildHtml(grid_obj){
+// Builds the HTML Table for a grid question (radio-selectable multi-option fields).
+function buildHtmlTable(grid_obj){
   // is there a hard/soft edit?
   let gridPrompt = "hardedit='false' softedit='false'";
   if (grid_obj.prompt) {
@@ -61,50 +69,77 @@ function buildHtml(grid_obj){
     }
   }
 
-  let shared_text = grid_text_displayif(grid_obj.shared_text)
-  shared_text = grid_replace_piped_variables(shared_text)
-
   // replace displayif and piped variables...
-  let grid_html = `<form ${grid_obj.args} class="container question" data-grid="true" ${gridPrompt}>`
-  grid_html+=`<div>${grid_text_displayif(shared_text)}</div>`
-  grid_html+='<ul class="quest-grid">'
-
-  // header line...
-  grid_html += '<li class="nr hr"></div>';
-  grid_obj.responses.forEach((resp,index) => {
-    grid_html += `<li class="hr">${resp.text}</div>`;
+  let shared_text = grid_text_displayif(grid_obj.shared_text)
+  shared_text = grid_replace_piped_variables(shared_text)  
+  
+  // Begin form and set up accessibility description.
+  // Ask the main question, then begin the table structure (this semantic HTML helps screen readers).
+  let grid_html = `
+      <form ${grid_obj.args} class="container question" data-grid="true" ${gridPrompt} aria-describedby="formDescription" role="form">
+        <div id="formDescription" class="sr-only" aria-live="polite">Please interact with the table below to answer the questions.</div>
+        <div>${grid_text_displayif(shared_text)}</div>
+        <table class="quest-grid">`;
+  
+  // Build the table header row with the question text and response headers. Start with a placeholder for the row header.
+  grid_html += '<thead class="hr" role="rowgroup"><tr><th class="nr hr"></th>';
+  grid_obj.responses.forEach((resp) => {
+    const header_text = resp.text;
+    grid_html += `<th class="hr" scope="col" data-header="${header_text}">${header_text}</th>`;
   });
-
+  grid_html += '</tr></thead><tbody role="rowgroup">';
+  
   // now lets handle each question...
   grid_obj.questions.forEach((question) => {
-    // check if there is a displayif for the entire question.  
-    let displayif = question.displayif ? `data-displayif="${encodeURIComponent(question.displayif)}"` : '';
-    // fill in the question text, replacing any displayif 
-    let question_text = grid_text_displayif(question.question_text)
-    question_text = grid_replace_piped_variables(question_text)
-    grid_html += `<li class="nr" data-question-id="${question.id}" data-gridrow="true" ${displayif}>${question_text}`
-    // for each possible response make a grid cell...
-    grid_obj.responses.forEach( (resp, resp_indx) => {
-      grid_html += `<li class="response" data-question-id="${question.id}"><input name="${question.id}" id="${question.id}_${resp_indx}" value="${resp.value}" type="${resp.type}" data-gridcell="true" data-grid="true"><label for="${question.id}_${resp_indx}">${resp.text}</label></li>`
-    })
-  })
-  grid_html+=`</ul></div>
-  <div class="container">
-    <div class="row">
-      <div class="col-md-3 col-sm-12">
-        <input type='submit' class='previous w-100' value='BACK'/>
-      </div>
-      <div class="col-md-6 col-sm-12">
-        <input type='submit' class='reset w-100' value='RESET ANSWER'/>
-      </div>
-      <div class="col-md-3 col-sm-12">
-        <input type='submit' class='next w-100' value='NEXT'/>
+    // check for row-level display if. Then check for displayif inside row text
+    const displayif = question.displayif ? `data-displayif="${encodeURIComponent(question.displayif)}"` : '';
+    const piped_question_text = grid_text_displayif(question.question_text);    
+    const question_text = grid_replace_piped_variables(piped_question_text);
+
+    if (question_text.id === "D_488415137") {
+      console.log('Question:', question);
+      console.log('Displayif:', displayif, 'Question Text:', question_text)
+    }
+    // Start the row for the question, then add the row header (question text)
+    grid_html +=
+      `<tr role="row" data-question-id="${question.id}" data-gridrow="true" aria-labelledby="qtext${question.id}" ${displayif}>
+        <th scope="row" id="qtext${question.id}" class="nr">${question_text}</th>`;
+
+
+    // All selectable responses for a given question share the same 'name' attribute to link them as a group
+    // The label is used as a click target for the radio/checkbox input
+    grid_obj.responses.forEach((resp, resp_index) => {
+        grid_html += `
+          <td class="response" data-question-id="${question.id}" data-header="${resp.text}" role="gridcell">
+            <input type="${resp.type}" name="${question.id}" id="${question.id}_${resp_index}" value="${resp.value}" data-gridcell="true" data-grid="true">
+            <label for="${question.id}_${resp_index}" id="label${question.id}_${resp_index}" class="custom-label">${resp.text} checkbox</label>
+          </td>`;
+    });
+
+    // Close the row for the question
+    grid_html += `</tr>`;
+  });
+  
+  grid_html+=`</tbody></table>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-3 col-sm-12">
+          <button type="submit" class="previous w-100" aria-label="Back to the previous section" data-click-type="previous">Back</button>
+        </div>
+        <div class="col-md-6 col-sm-12">
+          <button type="reset" class="reset w-100" aria-label="Reset answer for this question" data-click-type="reset">Reset Answer</button>
+        </div>
+        <div class="col-md-3 col-sm-12">
+          <button type="submit" class="next w-100" aria-label="Go to the next section" data-click-type="next">Next</button>
+        </div>
       </div>
     </div>
-  </div>
-  </form></form>`
-  return grid_html
+  </form>`;
+
+  return grid_html;
 }
+
+//NOTE: This function is not used in the current implementation
 function buildHtml_og(grid_obj) {
   let grid_head =
     '<div class="d-flex align-items-center border"><div class="col">Select an answer for each row below:</div>';
@@ -201,7 +236,7 @@ export function parseGrid(text) {
     grid_obj.args = grid_obj.args.replace(args_regex,(match,group1)=>{
       return `displayif=${encodeURIComponent(group1)}`
     })
-    console.log(grid_obj.args)
+    console.log(grid_obj.args) 
 
     //let question_regex = /\[([A-Z][A-Z0-9_]*)\](.*?);\s*(?=[\[\]])/g;     
     let question_regex = /\[([A-Z][A-Z0-9_]*)(,displayif=[^\]]+)?\](.*?)[;\]]/g;
@@ -236,5 +271,5 @@ export function parseGrid(text) {
       }
     }
   }
-  return buildHtml(grid_obj);
+  return buildHtmlTable(grid_obj);
 }

--- a/localforageDAO.js
+++ b/localforageDAO.js
@@ -39,7 +39,8 @@ export async function restoreResults(results) {
     if (typeof results[qid] == "string") {
       // in this case get the first input/textarea in the form and fill it in.
       let element = formElement.querySelector("input,textarea,select");
-      if (element.type == "radio") {
+      // null handle element, skip if null (load failing when participant is in the middle of unanswered SOCcer questions)
+      if (element?.type == "radio") {
         let selector = `input[value='${results[qid]}']`;
         let selectedRadioElement = formElement.querySelector(selector);
         if (selectedRadioElement) {
@@ -49,14 +50,17 @@ export async function restoreResults(results) {
         }
         radioAndCheckboxUpdate(selectedRadioElement);
       } else {
-        if (element.type == "submit") {
+        if (element?.type == "submit") {
           console.log(
             `local forage is trying to change the value of a submit button. Question ${qid} response value: ${results[qid]}; skipping this 1 value..`
           );
           return;
         }
-        element.value = results[qid];
-        textboxinput(element, false);
+
+        if (element?.value) {
+          element.value = results[qid];
+          textboxinput(element, false);
+        }
       }
 
       // we should return from here...

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -532,6 +532,7 @@ function exchangeValue(element, attrName, newAttrName) {
   return element;
 }
 
+// TODO: Look here for Safari text input delay issue.
 export function textboxinput(inputElement, validate = true) {
   /////////// To change all max attributes to input element ///////////
   // [...inputElement.parentElement.parentElement.children]
@@ -772,87 +773,77 @@ export function nextClick(norp, retrieve, store, rootElement) {
 }
 
 function setNumberOfQuestionsInModal(num, norp, retrieve, store, soft) {
-  let prompt = `There ${num > 1 ? "are" : "is"} ${num} question${num > 1 ? "s" : ""
-    } unanswered on this page. `;
-  if (!soft) {
+  const prompt = `There ${num > 1 ? "are" : "is"} ${num} unanswered question${num > 1 ? "s" : ""} on this page.`;
+  
+  const modalID = soft ? 'softModal' : 'hardModal';
+  const modal = new bootstrap.Modal(document.getElementById(modalID));
 
-    // set modal text...
-    document.getElementById(
-      "hardModalBodyText"
-    ).innerText = `${prompt} Please answer the question${num > 1 ? "s" : ""}.`;
+  document.getElementById(soft ? "modalBodyText" : "hardModalBodyText").innerText = `${prompt} ${soft ? "Would you like to continue?" : "Please answer the question(s)."}`;
 
-      // popup the modal..
-    const hardModal = new bootstrap.Modal(document.getElementById('hardModal'))
-    hardModal.show()
-    return null;
+  if (soft) {
+    const continueButton = document.getElementById("modalContinueButton");
+    continueButton.removeEventListener("click", continueButton.clickHandler);
+    continueButton.clickHandler = nextPage.bind(null, norp, retrieve, store);
+    continueButton.addEventListener("click", continueButton.clickHandler);
   }
-  let f1 = nextPage;
-  f1 = f1.bind(f1, norp, retrieve, store);
-  // set soft modal inner text...
-  document.getElementById(
-    "modalBodyText"
-  ).innerText = `${prompt} Would you like to continue?`;
-  document.getElementById("modalContinueButton").onclick = f1;
-  const softModal = new bootstrap.Modal(document.getElementById('softModal'))
-  softModal.show()
+
+  modal.show();
+
+  // Set focus to the modal title
+  document.getElementById("softModalTitle").focus();
+
+  let modalElement = modal._element;
+  modalElement.querySelector('.close').addEventListener('keydown', function(event) {
+    if (event.key === 'Escape') {
+      modal.hide();
+    }
+  });
 }
 
 // show modal function
 function showModal(norp, retrieve, store, rootElement) {
-  if (
-    norp.form.getAttribute("softedit") == "true" ||
-    norp.form.getAttribute("hardedit") == "true"
-  ) {
-    let numBlankReponses = [...norp.form.children]
-      .filter(
-        (x) =>
-          x.type &&
-          x.type != "hidden" &&
-          !x.hasAttribute("xor") &&
-          x.style.display != "none"
-      )
-      .reduce((t, x) => (x.value.length == 0 ? t + 1 : t), 0);
-    let hasNoResponses =
-      getSelected(norp.form).filter((x) => x.type !== "hidden").length == 0;
+  if (norp.form.getAttribute("softedit") == "true" || norp.form.getAttribute("hardedit") == "true") {
+    // Fieldset is the parent of the inputs for all but grid questions. Grid questions are in a table.
+    const fieldset = norp.form.querySelector('fieldset') || norp.form.querySelector('tbody');
 
-    if (norp.form.hasAttribute("radioCheckboxAndInput")) {
-      if (!radioCbHasAllAnswers(norp.form)) {
+    let numBlankResponses = [fieldset.children]
+      .filter(x => 
+        x.tagName !== 'DIV' && x.tagName !== 'BR' &&
+        x.type && x.type !== 'hidden' &&
+        x.value !== undefined &&
+        (x.style ? x.style.display !== "none" : true) &&
+        !x.hasAttribute("xor")
+      ).reduce((t, x) =>
+        x.value.length == 0 ? t + 1 : t, 0
+      );
+      
+    let hasNoResponses = getSelectedResponses(fieldset).filter((x) => x.type !== "hidden").length === 0;
+
+    if (fieldset.hasAttribute("radioCheckboxAndInput")) {
+      if (!radioCbHasAllAnswers(fieldset)) {
         hasNoResponses = true;
       }
     }
 
     if (norp.form.dataset.grid) {
-      if (!gridHasAllAnswers(norp.form)) {
+      if (!gridHasAllAnswers(fieldset)) {
         hasNoResponses = true;
       }
-      numBlankReponses = numberOfUnansweredGridQuestions(norp.form)
+      numBlankResponses = numberOfUnansweredGridQuestions(fieldset);
     }
-    // let tempVal = 0;
-    // if (hasNoResponses) {
-    //   tempVal = 0;
-    // } else {
-    //   tempVal = 1;
-    // }
-    if (numBlankReponses == 0 && hasNoResponses == true) {
-      numBlankReponses = 1;
-    } else if ((numBlankReponses == 0) == true && hasNoResponses == false) {
-      numBlankReponses = 0;
-    } else if ((numBlankReponses == 0) == false && hasNoResponses == true) {
-      numBlankReponses = numBlankReponses;
-    } else {
-      numBlankReponses = 0;
-    }
-    // numBlankReponses =
-    //   numBlankReponses == 0 && hasNoResponses ? tempVal : numBlankReponses;
 
-    if (numBlankReponses > 0) {
-      setNumberOfQuestionsInModal(
-        numBlankReponses,
-        norp,
-        retrieve,
-        store,
-        norp.form.getAttribute("softedit") == "true"
-      );
+    if (numBlankResponses == 0 && hasNoResponses == true) {
+      numBlankResponses = 1;
+    } else if ((numBlankResponses == 0) == true && hasNoResponses == false) {
+      numBlankResponses = 0;
+    } else if ((numBlankResponses == 0) == false && hasNoResponses == true) {
+      numBlankResponses = numBlankResponses;
+    } else {
+      numBlankResponses = 0;
+    }
+
+    if (numBlankResponses > 0) {
+      setNumberOfQuestionsInModal(numBlankResponses, norp, retrieve, store, norp.form.getAttribute("softedit") == "true");
       return null;
     }
   }
@@ -969,7 +960,7 @@ async function nextPage(norp, retrieve, store, rootElement) {
 
   // before we add the next question to the queue...
   // check for the displayif status...
-  while (nextElement.hasAttribute("displayif")) {
+  while (nextElement?.hasAttribute("displayif")) {
     // not sure what to do if the next element is is not a question ...
     if (nextElement.classList.contains("question")) {
       let display = evaluateCondition(nextElement.getAttribute("displayif"));
@@ -1019,11 +1010,27 @@ export async function submitQuestionnaire(store, questName) {
   }
 }
 function exitLoop(nextElement) {
+  if (!nextElement) {
+    console.error("nextElement is null or undefined");
+    return null;
+  }
+
   if (nextElement.hasAttribute("firstquestion")) {
-    let loopMax = parseInt(document.getElementById(nextElement.getAttribute("loopmax"))
-      .value);
+    let loopMaxElement = document.getElementById(nextElement.getAttribute("loopmax"));
+    if (!loopMaxElement) {
+      console.error(`LoopMaxElement is null or undefined for ${nextElement.id}`);
+      return nextElement;
+    }
+
+    let loopMax = parseInt(loopMaxElement.value);
     let firstQuestion = parseInt(nextElement.getAttribute("firstquestion"));
     let loopIndex = parseInt(nextElement.getAttribute("loopindx"));
+
+    if (isNaN(loopMax) || isNaN(firstQuestion) || isNaN(loopIndex)) {
+      console.error(`LoopMax, firstQuestion, or loopIndex is NaN for ${nextElement.id}`);
+      return nextElement;
+    }
+
     if (math.evaluate(firstQuestion > loopMax)) {
       questionQueue.pop();
       questionQueue.add(`_CONTINUE${loopIndex}_DONE`);
@@ -1031,10 +1038,12 @@ function exitLoop(nextElement) {
       nextElement = document.getElementById(nextQuestionId.value);
     }
   }
+  
   return nextElement;
 }
 
 export function displayQuestion(nextElement) {
+
   [...nextElement.querySelectorAll("span[forid]")].map((x) => {
     let defaultValue = x.getAttribute("optional")
     x.innerHTML = math.valueOrDefault(decodeURIComponent(x.getAttribute("forid")), defaultValue)
@@ -1088,24 +1097,17 @@ export function displayQuestion(nextElement) {
       e.innerText = math.evaluate(decodeURIComponent(e.dataset.gridreplace))
     }
   });
-  //check if grid elements needs to be shown
-  // concern:: in the grid you can have style:none and class="d-flex"
-  // currently this SHOWS the row.  If this changes in the future,
-  // it may have to be fixed.
-  Array.from(nextElement.querySelectorAll("[data-gridrow][data-displayif]"))
-    .forEach((elm) => {
-      let f = evaluateCondition(decodeURIComponent(elm.dataset.displayif));
+  
+  // Check if grid elements need to be shown. Elm is a <tr>. If f !== true, remove the row (elm) from the DOM.
+  Array.from(nextElement.querySelectorAll("[data-gridrow][data-displayif]")).forEach((elm) => {
+    const f = evaluateCondition(decodeURIComponent(elm.dataset.displayif));
+    console.log(`checking the datagrid for displayif... ${elm.dataset.questionId} ${f}`)
 
-      console.log(elm)
-      console.log(`checking the datagrid for displayif... ${elm.dataset.questionId} ${f}`)
-      
-      Array.from(elm.parentElement.querySelectorAll(`[data-question-id=${elm.dataset.questionId}]`)).forEach(resp => {
-        console.log(resp)
-        resp.style.display=(f)?'block':'none'
-      })
-//      elm.classList.add((f) ? "d-flex" : "collapse")
-//      elm.classList.remove((f) ? "collapse" : "d-flex")
-    });
+    if (f !== true) {
+      elm.remove();
+      //elm.closest('tr').remove(); // this is the same as elm.remove()...slower but more flexible. temp leaving in case there are cases I've missed.
+    }
+  });
 
   // check min/max for variable substitution in validation
   /*function exchangeValue(element, attrName, newAttrName) {
@@ -1181,7 +1183,76 @@ export function displayQuestion(nextElement) {
   updateTree();
 
   questionQueue.ptree();
+
+  // manage the question-specific listeners
+  refreshListeners(nextElement);
+
   return nextElement;
+}
+
+let debounceHandler;
+
+function refreshListeners(nextElement) {
+  removeListeners();
+  debounceHandler = null;
+  addListeners(nextElement);
+}
+
+function removeListeners() {
+  const textInputs = document.querySelectorAll('input[type="text"]');
+  
+  if (debounceHandler) {
+    textInputs.forEach(textInput => {
+        textInput.removeEventListener('input', debounceHandler);
+    });
+  }
+}
+
+function addListeners(nextElement) {
+  const textInputs = nextElement.querySelectorAll('input[type="text"]');
+
+  if (!debounceHandler) {
+    debounceHandler = debounce(handleOtherTextInputKeyPress, 200); // 200ms
+  }
+  
+  // Find the associated checkbox/radio element. Note: Some are checkboxes and some are radios though they look the same.
+  textInputs.forEach(textInput => {
+      textInput.addEventListener('input', debounceHandler);
+      const responseContainer = textInput.closest('.response');
+
+      if (responseContainer) {
+          const checkboxOrRadio = responseContainer.querySelector('input[type="checkbox"], input[type="radio"]');
+
+          if (checkboxOrRadio) {
+              checkboxOrRadio.addEventListener('click', () => {
+                  textInput.focus(); // Focus the text input on checkbox/radio click
+              });
+          }
+      }
+  });
+}
+
+// Simulate a click on the checkbox (turn the tile blue) when the text input is used to enter "Other" text values.
+// Get the parent response container, then get the checkbox element that wraps the input field.
+function handleOtherTextInputKeyPress(event) {
+  const responseTarget = event.target.closest('.response');
+  const checkboxOrRadioEle = responseTarget?.querySelector('input[type="checkbox"], input[type="radio"]');
+  
+  if (checkboxOrRadioEle) {
+      event.target.value ? checkboxOrRadioEle.checked = true : checkboxOrRadioEle.checked = false;
+  }
+}
+
+function debounce(func, wait) {
+  let timeout;
+  return function execute(...args) {
+      const later = () => {
+          clearTimeout(timeout);
+          func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+  };
 }
 
 // Check whether the browser supports "month" input type.
@@ -1221,7 +1292,7 @@ export async function previousClicked(norp, retrieve, store, rootElement) {
 // question queue.  It always returns null;
 function checkForSkips(questionElement) {
   // get selected responses
-  let selectedElements = getSelected(questionElement);
+  let selectedElements = getSelectedResponses(questionElement);
 
   let numSelected = selectedElements.filter((x) => x.type != "hidden").length;
   // if there are NO non-hidden responses ...
@@ -1280,28 +1351,27 @@ function checkValid(questionElement) {
 }
 
 //check if grids has all answers
-export function gridHasAllAnswers(questionElement) {
-  let gridRows = Array.from(questionElement.querySelectorAll("[data-gridrow]"));
+export function gridHasAllAnswers(questionFieldset) {
+  let gridRows = Array.from(questionFieldset.querySelectorAll("tr[data-gridrow='true']"));
 
   const checked = (element) => element.checked;
   return gridRows.reduce( (acc,current,index) => {
-    if (current.style.display=='none') return acc
+    if (current.style.display=='none') return acc // skip hidden rows
 
     let name = current.dataset.questionId
-    let currentResponses = Array.from(current.parentElement.querySelectorAll(`[name="${name}"]`))
+    let currentResponses = Array.from(current.parentElement.querySelectorAll(`input[type="radio"][name="${name}"]`))
     return acc && currentResponses.some(checked)
   },true)
 }
 
-export function numberOfUnansweredGridQuestions(questionElement) {
-  let gridRows = Array.from(questionElement.querySelectorAll("[data-gridrow]"));
-
+export function numberOfUnansweredGridQuestions(questionFieldset) {
+  let gridRows = Array.from(questionFieldset.querySelectorAll("tr[data-gridrow='true']"));
   const checked = (element) => element.checked;
   return gridRows.reduce( (acc,current,index) => {
-    if (current.style.display=='none') return acc
+    if (current.style.display=='none') return acc // skip hidden rows
 
     let name = current.dataset.questionId
-    let currentResponses = Array.from(current.parentElement.querySelectorAll(`[name="${name}"]`))
+    let currentResponses = Array.from(current.querySelectorAll(`input[type="radio"][name="${name}"]`));
     return currentResponses.some(checked)?acc:(acc+1)
   },0)
 }
@@ -1325,43 +1395,15 @@ export function radioCbHasAllAnswers(questionElement) {
   }
   return hasAllAnswers;
 }
-export function getSelected(questionElement) {
-  // look for radio boxes, checkboxes, and  hidden elements
-  // for checked items.  Return all checked items.
-  // If nothing is checked, an empty array should be returned.
-  // var rv = [
-  //   ...questionElement.querySelectorAll(
-  //     "input[type='radio'],input[type='checkbox'],input[type='hidden'],input[type='number']"
-  //   )
-  // ];
 
-  var rv1 = [
-    ...questionElement.querySelectorAll(
-      "input[type='radio'],input[type='checkbox']"
-    ),
-  ];
+// Look at radio, checkboxes, input fields, and hidden elements and return all checked or filled items.
+// If nothing is checked, return empty array.
+export function getSelectedResponses(questionElement) {
+  const radiosAndCheckboxes = [...questionElement.querySelectorAll("input[type='radio'],input[type='checkbox']")].filter((x) => x.checked);
+  const inputFields = [...questionElement.querySelectorAll("input[type='number'], input[type='text'], input[type='date'], input[type='month'], input[type='email'], input[type='time'], input[type='tel'], textarea, option")].filter((x) => x.value.length > 0);
+  const hiddenInputs = [...questionElement.querySelectorAll("input[type='hidden']")].filter((x) => x.hasAttribute("checked"));
 
-  var rv2 = [
-    ...questionElement.querySelectorAll(
-      "input[type='number'], input[type='text'], input[type='date'], input[type='month'], input[type='email'], input[type='time'], input[type='tel'], textarea, option"
-    ),
-  ];
-
-  var rv3 = [...questionElement.querySelectorAll("input[type='hidden']")];
-
-  rv1 = rv1.filter((x) => x.checked);
-  rv2 = rv2.filter((x) => x.value.length > 0);
-  rv3 = rv3.filter((x) => x.hasAttribute("checked"));
-
-  // rv = rv.filter(x =>
-  //   x.type == "radio" || x.type == "checkbox" || x.type == "hidden"
-  //     ? x.checked
-  //     : x.value.length > 0
-  // );
-
-  // we may need to guarentee that the hidden comes last.
-  rv1 = rv1.concat(rv2);
-  return rv1.concat(rv3);
+  return [...radiosAndCheckboxes, ...inputFields, ...hiddenInputs];
 }
 
 // create a blank object for collecting

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -773,12 +773,13 @@ export function nextClick(norp, retrieve, store, rootElement) {
 }
 
 function setNumberOfQuestionsInModal(num, norp, retrieve, store, soft) {
-  const prompt = `There ${num > 1 ? "are" : "is"} ${num} unanswered question${num > 1 ? "s" : ""} on this page.`;
+  const prompt = `There ${num > 1 ? "are" : "is"} ${num} question${num > 1 ? "s" : ""} unanswered on this page.`;
   
   const modalID = soft ? 'softModal' : 'hardModal';
   const modal = new bootstrap.Modal(document.getElementById(modalID));
-
-  document.getElementById(soft ? "modalBodyText" : "hardModalBodyText").innerText = `${prompt} ${soft ? "Would you like to continue?" : "Please answer the question(s)."}`;
+  const softModalText = "Would you like to continue?";
+  const hardModalText = `Please answer the question${num > 1 ? "s" : ""}.`;
+  document.getElementById(soft ? "modalBodyText" : "hardModalBodyText").innerText = `${prompt} ${soft ? softModalText : hardModalText}`;
 
   if (soft) {
     const continueButton = document.getElementById("modalContinueButton");
@@ -1109,20 +1110,6 @@ export function displayQuestion(nextElement) {
     }
   });
 
-  // check min/max for variable substitution in validation
-  /*function exchangeValue(element, attrName, newAttrName) {
-    let attr = element.getAttribute(attrName);
-    if (attr) {
-      let isnum = /^[\d\.]+$/.test(attr);
-      if (!isnum) {
-        let tmpVal = evaluateCondition(attr);
-        console.log('------------exchanged Vals-----------------')
-        console.log(`${element} , ${attrName} , ${newAttrName} , ${tmpVal}`)
-        element.setAttribute(newAttrName, tmpVal);
-      }
-    }
-    return element;
-  }*/
   //Replacing all default HTML form validations with datasets
 
   [...nextElement.querySelectorAll("input[required]")].forEach((element) => {
@@ -1174,6 +1161,16 @@ export function displayQuestion(nextElement) {
       input.setAttribute('placeholder', 'YYYY-MM');
     });
   }
+
+  // Hide br elements that directly follow hidden elements.
+  nextElement.querySelectorAll(`[style*="display: none"]+br`).forEach((e) => {
+    e.style = "display: none";
+  });
+
+  // Add aria-hidden to all remaining br elements. This keeps the screen reader from reading them as 'Empty Group'.
+  nextElement.querySelectorAll("br").forEach((br) => {
+    br.setAttribute("aria-hidden", "true");
+  });
 
   //move to the next question...
   nextElement.classList.add("active");

--- a/replace2.js
+++ b/replace2.js
@@ -45,6 +45,7 @@ transform.render = async (obj, divId, previousResults = {}) => {
   moduleParams.renderObj = obj;
   moduleParams.previousResults = previousResults;
   moduleParams.soccer = obj.soccer;
+  moduleParams.delayedParameterArray = obj.delayedParameterArray;
   rootElement = divId;
   let contents = "";
 

--- a/replace2.js
+++ b/replace2.js
@@ -52,6 +52,7 @@ transform.render = async (obj, divId, previousResults = {}) => {
 
   if (obj.text) contents = obj.text;
 
+  // TODO: should these stylesheets have local refs instead (pulled from the CDN instead of the GitHub repo)?
   if (obj.url) {
     contents = await (await fetch(obj.url)).text();
     moduleParams.config = contents
@@ -1033,7 +1034,6 @@ transform.render = async (obj, divId, previousResults = {}) => {
   // handle text in combobox label...
   [...divElement.querySelectorAll("label input,label textarea")].forEach(inputElement => {
       let radioCB = document.getElementById(inputElement.id)
-      //let radioCB = document.getElementById(inputElement.closest('label').htmlFor)
 
       if (radioCB) { 
         let callback = (event)=>{
@@ -1208,17 +1208,26 @@ function stopSubmit(event) {
   const clickType = event.submitter.getAttribute('data-click-type');
   const buttonClicked = event.target.querySelector(`.${clickType}`);
 
-  if (clickType === 'previous') { 
-    resetChildren(event.target.elements);
-    previousClicked(buttonClicked, moduleParams.renderObj.retrieve, moduleParams.renderObj.store, rootElement);
-  } else if (clickType === 'reset') {
-    resetChildren(event.target.elements);
-  } else if (clickType === 'submitSurvey') {
-    new bootstrap.Modal(document.getElementById('submitModal')).show();
-  } else if (clickType === 'next') {
-    nextClick(buttonClicked, moduleParams.renderObj.retrieve, moduleParams.renderObj.store, rootElement);
-  } else {
-    console.error(`ERROR: Unknown button clicked: ${clickType}`);
+  switch (clickType) {
+    case 'previous':
+      resetChildren(event.target.elements);
+      previousClicked(buttonClicked, moduleParams.renderObj.retrieve, moduleParams.renderObj.store, rootElement);
+      break;
+
+    case 'reset':
+      resetChildren(event.target.elements);
+      break;
+
+    case 'submitSurvey':
+      new bootstrap.Modal(document.getElementById('submitModal')).show();
+      break;
+
+    case 'next':
+      nextClick(buttonClicked, moduleParams.renderObj.retrieve, moduleParams.renderObj.store, rootElement);
+      break;
+
+    default:
+      console.error(`ERROR: Unknown button clicked: ${clickType}`);
   }
 }
 


### PR DESCRIPTION
Hi @danielruss @anthonypetersen, please review this when you have a chance. Thank you.

PR: JAWS / Accessibility enhancements
Related: https://github.com/episphere/connect/issues/931

• Accessibility enhancements for easier screen reader use.
• Update grid to table (screen reader friendly), increase click target size.
• Update grid handlers for new table format.
• Add checkmark graphic to grid.
• Add card layout to mobile grid.
• Add aria properties to some inputs.
• Autofocus ‘other’ and ‘please describe’ text boxes on click.
• Autoclick ‘other’ and ‘please describe’ text boxes on text input.
• Update modal for accessible navigation.
• Refactor stopSubmit.

TODO: `<br>` tags need to be handled in some browsers — they read “empty group” which can be confusing with a screen reader.

Example: updated grid view with larger click targets
<img width="561" alt="Screenshot 2024-05-13 at 9 38 16 AM" src="https://github.com/episphere/quest/assets/93854858/17f0db1c-7ee0-441f-9983-0addff13544a">
