### PR TITLE
accessibility updates

### DIFF
--- a/ActiveLogic.css
+++ b/ActiveLogic.css
@@ -162,52 +162,96 @@ for bootstrap -xs
 .quest-grid.table-layout tr {
   width: auto;
   display: table-row;
+  font-size: clamp(12px, 1.5vw, 16px);
 }
-
-.quest-grid.table-layout th, .quest-grid.table-layout td {
-  padding: 5px;
+ 
+.quest-grid.table-layout th.hr {
+  padding: .2vw;
   text-align: center;
   vertical-align: middle;
-  height: 50px;
+  height: auto;
+  position: relative;
+  background-color: transparent;
+  border: none;
+  font-weight: normal;
+  font-size: clamp(11px, 1.8vw, 16px);
+  word-wrap: break-word;
+}
+
+.quest-grid.table-layout th.nr {
+  padding: clamp(5px, 1vw, 10px);
+  text-align: center;
+  vertical-align: middle;
+  height: auto;
+  position: relative;
+  background-color: transparent;
+  border: none;
+  font-size: clamp(12px, 1.5vw, 16px);
+}
+
+.quest-grid.table-layout td {
+  padding: .5vw;
+  text-align: center;
+  vertical-align: middle;
+  height: auto;
   position: relative;
   background-color: transparent;
   border: none;
 }
 
 .quest-grid.table-layout th.nr, .quest-grid.table-layout td.nr {
-  font-weight: bold;
   text-align: left;
+  font-size: clamp(12px, 1.5vw, 16px);
 }
 
 .quest-grid.table-layout input[type="radio"] {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
 }
 
-/* Additional styles to ensure the label is large enough to comfortably contain the circles */
 .quest-grid.table-layout .custom-label {
   position: relative;
-  height: 50px;
-  min-width: 50px;
+  height: clamp(19px, 2vw, 34px);
+  min-width: clamp(19px, 2vw, 34px);
   color: transparent;
   background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   border: none;
   outline: none;
+  overflow: hidden;
+  padding: 1em;
 }
 
-/* Styling for the custom label to always have an unfilled circle */
 .quest-grid.table-layout .custom-label::before {
   content: '';
   display: block;
-  width: 26px;
-  height: 26px;
-  border: 2px solid #cccccc;
-  border-radius: 50%; /* Circle */
+  width: clamp(19px, 2vw, 34px);
+  height: clamp(19px, 2vw, 34px);
+  border: 0.15vw solid #b3b3b3;
+  border-radius: 50%;
   position: absolute;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
   background-color: transparent;
+}
+
+.quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
+  content: '';
+  display: block;
+  width: clamp(14px, 1.4vw, 23px);
+  height: clamp(14px, 1.4vw, 23px);
+  border-radius: 50%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #327ABB;
 }
 
 .quest-grid.table-layout .custom-label:hover {
@@ -216,37 +260,23 @@ for bootstrap -xs
   outline: none;
 }
 
-/* Hover effect for the label */
 .quest-grid .custom-label:hover::before {
   border-color: #1c5d86;
-  box-shadow: 0 0 8px #ccc;
-}
-
-/* Styling for when the radio button is checked */
-.quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
-  content: '';
-  display: block;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%; /* Circle */
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  background-color: #327ABB;
+  box-shadow: 0 0 .75vw #b3b3b3;
 }
 
 .quest-grid.table-layout input[type="radio"]:checked + .custom-label {
   border: none;
   background-color: transparent;
   color: transparent;
-}
+} 
 
 @media screen and (min-width: 576px) {
   /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
   .quest-grid.table-layout th:first-child, .quest-grid td:first-child {
-    width: 35%;
-    font-weight: bold;
+    width: 25%;
+    font-weight: normal;
+    font-size: clamp(12px, 1.5vw, 16px);
   }
 }
 
@@ -259,6 +289,10 @@ for bootstrap -xs
     display: block;
   }
 
+  .quest-grid.table-layout th.nr {
+    font-weight: bold;
+    font-size: 16px;
+  }
   .quest-grid.table-layout .custom-label {
     position: absolute;
     top: 0;

--- a/ActiveLogic.css
+++ b/ActiveLogic.css
@@ -168,7 +168,7 @@ for bootstrap -xs
 .quest-grid.table-layout th.hr {
   padding: .2vw;
   text-align: center;
-  vertical-align: middle;
+  vertical-align: top;
   height: auto;
   position: relative;
   background-color: transparent;

--- a/Default.css
+++ b/Default.css
@@ -96,52 +96,96 @@ for bootstrap -xs
 .quest-grid.table-layout tr {
   width: auto;
   display: table-row;
+  font-size: clamp(12px, 1.5vw, 16px);
 }
-
-.quest-grid.table-layout th, .quest-grid.table-layout td {
-  padding: 5px;
+ 
+.quest-grid.table-layout th.hr {
+  padding: .2vw;
   text-align: center;
   vertical-align: middle;
-  height: 50px;
+  height: auto;
+  position: relative;
+  background-color: transparent;
+  border: none;
+  font-weight: normal;
+  font-size: clamp(11px, 1.8vw, 16px);
+  word-wrap: break-word;
+}
+
+.quest-grid.table-layout th.nr {
+  padding: clamp(5px, 1vw, 10px);
+  text-align: center;
+  vertical-align: middle;
+  height: auto;
+  position: relative;
+  background-color: transparent;
+  border: none;
+  font-size: clamp(12px, 1.5vw, 16px);
+}
+
+.quest-grid.table-layout td {
+  padding: .5vw;
+  text-align: center;
+  vertical-align: middle;
+  height: auto;
   position: relative;
   background-color: transparent;
   border: none;
 }
 
 .quest-grid.table-layout th.nr, .quest-grid.table-layout td.nr {
-  font-weight: bold;
   text-align: left;
+  font-size: clamp(12px, 1.5vw, 16px);
 }
 
 .quest-grid.table-layout input[type="radio"] {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
 }
 
-/* Additional styles to ensure the label is large enough to comfortably contain the circles */
 .quest-grid.table-layout .custom-label {
   position: relative;
-  height: 50px;
-  min-width: 50px;
+  height: clamp(19px, 2vw, 34px);
+  min-width: clamp(19px, 2vw, 34px);
   color: transparent;
   background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   border: none;
   outline: none;
+  overflow: hidden;
+  padding: 1em;
 }
 
-/* Styling for the custom label to always have an unfilled circle */
 .quest-grid.table-layout .custom-label::before {
   content: '';
   display: block;
-  width: 26px;
-  height: 26px;
-  border: 2px solid #cccccc;
-  border-radius: 50%; /* Circle */
+  width: clamp(19px, 2vw, 34px);
+  height: clamp(19px, 2vw, 34px);
+  border: 0.15vw solid #b3b3b3;
+  border-radius: 50%;
   position: absolute;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
   background-color: transparent;
+}
+
+.quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
+  content: '';
+  display: block;
+  width: clamp(14px, 1.4vw, 23px);
+  height: clamp(14px, 1.4vw, 23px);
+  border-radius: 50%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #327ABB;
 }
 
 .quest-grid.table-layout .custom-label:hover {
@@ -150,37 +194,23 @@ for bootstrap -xs
   outline: none;
 }
 
-/* Hover effect for the label */
 .quest-grid .custom-label:hover::before {
   border-color: #1c5d86;
-  box-shadow: 0 0 8px #ccc;
-}
-
-/* Styling for when the radio button is checked */
-.quest-grid.table-layout input[type="radio"]:checked + .custom-label::after {
-  content: '';
-  display: block;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%; /* Circle */
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  background-color: #327ABB;
+  box-shadow: 0 0 .75vw #b3b3b3;
 }
 
 .quest-grid.table-layout input[type="radio"]:checked + .custom-label {
   border: none;
   background-color: transparent;
   color: transparent;
-}
+} 
 
 @media screen and (min-width: 576px) {
   /* Emphasize the first table column. Then let the browser calculate the width for the remaining columns */
   .quest-grid.table-layout th:first-child, .quest-grid td:first-child {
-    width: 35%;
-    font-weight: bold;
+    width: 25%;
+    font-weight: normal;
+    font-size: clamp(12px, 1.5vw, 16px);
   }
 }
 
@@ -193,6 +223,10 @@ for bootstrap -xs
     display: block;
   }
 
+  .quest-grid.table-layout th.nr {
+    font-weight: bold;
+    font-size: 16px;
+  }
   .quest-grid.table-layout .custom-label {
     position: absolute;
     top: 0;

--- a/buildGrid.js
+++ b/buildGrid.js
@@ -76,7 +76,7 @@ function buildHtmlTable(grid_obj){
       <form ${grid_obj.args} class="container question" data-grid="true" ${gridPrompt} aria-describedby="formDescription" role="form">
         <div id="formDescription" class="sr-only" aria-live="polite">Please interact with the table below to answer the questions.</div>
         <div>${grid_text_displayif(shared_text)}</div>
-        <table class="quest-grid table-layout">`;
+          <table class="quest-grid table-layout table">`;
   
   // Build the table header row with the question text and response headers. Start with a placeholder for the row header.
   grid_html += '<thead class="hr" role="rowgroup"><tr><th class="nr hr"></th>';

--- a/replace2.js
+++ b/replace2.js
@@ -542,7 +542,7 @@ transform.render = async (obj, divId, previousResults = {}) => {
       }
 
       // Handle not converted and not yet calculated min and max values
-      const minMaxValueTest = (value) => { return value && !value.startsWith('valueOr') && !value.startsWith('isDefined') && value !== '0' ? value : ''; }
+      const minMaxValueTest = (value) => { return value && !value.startsWith('valueOr') && !value.includes('isDefined') && value !== '0' ? value : ''; }
       const min = minMaxValueTest(optionObj.min);
       const max = minMaxValueTest(optionObj.max);
 

--- a/replace2.js
+++ b/replace2.js
@@ -555,7 +555,7 @@ transform.render = async (obj, divId, previousResults = {}) => {
 
       //onkeypress forces whole numbers
       return `<input type='number' aria-label='${value}' step='any' onkeypress='return (event.charCode == 8 || event.charCode == 0 || event.charCode == 13) ? null : event.charCode >= 48 && event.charCode <= 57' name='${questID}' ${options}>
-              <div id="${elementId}-desc" class="sr-only">${descriptionText}</div>`;
+              <div id="${elementId}-desc" class="sr-only">${descriptionText}</div><br>`;
   }
 
     // replace |__| or [text box:xxx] with an input box...


### PR DESCRIPTION
@danielruss @anthonypetersen please review & advise on this when you can. Thanks.

Related: https://github.com/episphere/quest/issues/438 & https://github.com/episphere/connect/issues/931

This PR addresses:
* Responsive sizing for the grids.
* Improved accessible targeting for the grids.
* Grid misalignment in renderer should be fixed.
* Focus on the question text for screen readers (next, back, and modal close buttons.
* Handle placeholder for all `isDefined` min & max numeric values.

**Desktop:**
<img width="1005" alt="Screenshot 2024-05-22 at 9 14 31 AM" src="https://github.com/episphere/quest/assets/93854858/787c7f38-0a58-40f7-8adf-759465acb151">

**Tablet (smallest before switching to mobile view:**
<img width="498" alt="Screenshot 2024-05-22 at 9 14 46 AM" src="https://github.com/episphere/quest/assets/93854858/7673cd32-6d24-4deb-8ccc-0215f2ccedc2">

**Renderer:**
<img width="783" alt="Screenshot 2024-05-22 at 9 04 16 AM" src="https://github.com/episphere/quest/assets/93854858/d3c7baec-e9e4-426a-8eb9-fa8c627c8753">

