### PR TITLE
added logging information

### DIFF
--- a/questionnaire.js
+++ b/questionnaire.js
@@ -1050,7 +1050,7 @@ function exitLoop(nextElement) {
     let loopIndex = parseInt(nextElement.getAttribute("loopindx"));
 
     if (isNaN(loopMax) || isNaN(firstQuestion) || isNaN(loopIndex)) {
-      console.error(`LoopMax, firstQuestion, or loopIndex is NaN for ${nextElement.id}`);
+      console.error(`LoopMax, firstQuestion, or loopIndex is NaN for ${nextElement.id}: loopMax=${loopMax}, firstQuestion=${firstQuestion}, loopIndex=${loopIndex}`);
       return nextElement;
     }
 


### PR DESCRIPTION
Issues occurred where the following error handling block was hit:

`if (isNaN(loopMax) || isNaN(firstQuestion) || isNaN(loopIndex))`

We aren't sure how this happened and this code review is just to add additional information to the console error if it occurs again.