### PR TITLE
bugfix Questionnarie repo #385 -> look for .children inside fieldset

### DIFF
--- a/questionnaire.js
+++ b/questionnaire.js
@@ -1093,14 +1093,10 @@ export function displayQuestion(nextElement) {
   );
 
   // check all responses for next question
-  [...(nextElement.querySelector('fieldset')?.children || [])]
-    .filter((x) => {
-      return x.hasAttribute("displayif");
-    })
-    .map((elm) => {
-      let f = evaluateCondition(elm.getAttribute("displayif"));
-      elm.style.display = f ? null : "none";
-    });
+  [...nextElement.querySelectorAll('[displayif]')].map((elm) => {
+    let f = evaluateCondition(elm.getAttribute("displayif"));
+    elm.style.display = f ? null : "none";
+  });
 
   // check for displayif spans...
   Array.from(nextElement.querySelectorAll("span[displayif],div[displayif]"))

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -1101,7 +1101,7 @@ export function displayQuestion(nextElement) {
       let f = evaluateCondition(elm.getAttribute("displayif"));
       elm.style.display = f ? null : "none";
     });
-    
+
   // check for displayif spans...
   Array.from(nextElement.querySelectorAll("span[displayif],div[displayif]"))
     .map(elm => {
@@ -1136,7 +1136,6 @@ export function displayQuestion(nextElement) {
   
   // Check if grid elements need to be shown. Elm is a <tr>. If f !== true, remove the row (elm) from the DOM.
   Array.from(nextElement.querySelectorAll("[data-gridrow][data-displayif]")).forEach((elm) => {
-    console.log(`GRID displayif: ${elm}`)
     const f = evaluateCondition(decodeURIComponent(elm.dataset.displayif));
     console.log(`checking the datagrid for displayif... ${elm.dataset.questionId} ${f}`)
 

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -1093,7 +1093,7 @@ export function displayQuestion(nextElement) {
   );
 
   // check all responses for next question
-  [...nextElement.children]
+  [...(nextElement.querySelector('fieldset')?.children || [])]
     .filter((x) => {
       return x.hasAttribute("displayif");
     })
@@ -1101,6 +1101,7 @@ export function displayQuestion(nextElement) {
       let f = evaluateCondition(elm.getAttribute("displayif"));
       elm.style.display = f ? null : "none";
     });
+    
   // check for displayif spans...
   Array.from(nextElement.querySelectorAll("span[displayif],div[displayif]"))
     .map(elm => {
@@ -1135,6 +1136,7 @@ export function displayQuestion(nextElement) {
   
   // Check if grid elements need to be shown. Elm is a <tr>. If f !== true, remove the row (elm) from the DOM.
   Array.from(nextElement.querySelectorAll("[data-gridrow][data-displayif]")).forEach((elm) => {
+    console.log(`GRID displayif: ${elm}`)
     const f = evaluateCondition(decodeURIComponent(elm.dataset.displayif));
     console.log(`checking the datagrid for displayif... ${elm.dataset.questionId} ${f}`)
 

--- a/replace2.js
+++ b/replace2.js
@@ -1211,11 +1211,13 @@ function stopSubmit(event) {
   switch (clickType) {
     case 'previous':
       resetChildren(event.target.elements);
+      event.target.value = undefined;
       previousClicked(buttonClicked, moduleParams.renderObj.retrieve, moduleParams.renderObj.store, rootElement);
       break;
 
     case 'reset':
       resetChildren(event.target.elements);
+      event.target.value = undefined;
       break;
 
     case 'submitSurvey':


### PR DESCRIPTION
Bug Fix 1: after adding the accessible fieldset wrapper, we need to look for `.children` inside that fieldset.
Bug fix 2: reinstate missed conditions in `stopSubmit()` to reset `event.target.value` on back/reset click.

Related:
https://github.com/episphere/connect/issues/1061
https://github.com/episphere/questionnaire/issues/385
https://github.com/episphere/questionnaire/issues/388