### PR TITLE
reorder button on large,not med devices

### DIFF
--- a/replace2.js
+++ b/replace2.js
@@ -755,13 +755,13 @@ transform.render = async (obj, divId, previousResults = {}) => {
         </fieldset>
         <div class="py-0">
           <div class="row">
-            <div class="col-md-3 col-sm-12 order-3 order-md-1">
+            <div class="col-lg-3 col-12 order-3 order-lg-1">
               ${prevButton}
             </div>
-            <div class="col-md-6 col-sm-12 order-2">
+            <div class="col-lg-6 col-12 order-2">
               ${resetButton}
             </div>
-            <div class="col-md-3 col-sm-12 order-1 order-md-3">
+            <div class="col-lg-3 col-12 order-1 order-lg-3">
               ${nextButton}
             </div>
           </div>


### PR DESCRIPTION
On small and xs devices, the order of the buttons was next/reset/prev.  medium (>=768px) and larger was prev - reset and next on the same line.  The fix kept the order of medium devices as nex/reset/prev and pushed the swapping to large devices (>=992px).  Also fixed a small but that xs devices would not be vertical.